### PR TITLE
Add initial iOS FriendFinder app

### DIFF
--- a/FriendFinder/App/FriendFinderApp.swift
+++ b/FriendFinder/App/FriendFinderApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct FriendFinderApp: App {
+    @StateObject private var locationManager = LocationManager()
+    @StateObject private var service = FriendLocationService()
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(locationManager)
+                .environmentObject(service)
+                .onAppear {
+                    service.start()
+                }
+        }
+    }
+}

--- a/FriendFinder/Model/LocationManager.swift
+++ b/FriendFinder/Model/LocationManager.swift
@@ -1,0 +1,29 @@
+import Foundation
+import CoreLocation
+import MapKit
+import Combine
+
+class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+    @Published var lastLocation: CLLocation?
+    @Published var region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 0, longitude: 0), span: MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005))
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+    }
+
+    func requestPermission() {
+        manager.requestWhenInUseAuthorization()
+        manager.startUpdatingLocation()
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        DispatchQueue.main.async {
+            self.lastLocation = location
+            self.region.center = location.coordinate
+        }
+    }
+}

--- a/FriendFinder/Networking/FriendLocationService.swift
+++ b/FriendFinder/Networking/FriendLocationService.swift
@@ -1,0 +1,28 @@
+import Foundation
+import MapKit
+
+struct Friend: Identifiable, Codable {
+    let id: String
+    let coordinate: CLLocationCoordinate2D
+}
+
+class FriendLocationService: ObservableObject {
+    @Published var friends: [Friend] = []
+    private var timer: Timer?
+
+    func start() {
+        // Start periodic location updates
+        timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
+            self.fetchLocations()
+            self.sendMyLocation()
+        }
+    }
+
+    func sendMyLocation() {
+        // TODO: Implement network call to send current location to backend
+    }
+
+    func fetchLocations() {
+        // TODO: Implement network call to retrieve friends' locations from backend
+    }
+}

--- a/FriendFinder/View/ContentView.swift
+++ b/FriendFinder/View/ContentView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import MapKit
+
+struct ContentView: View {
+    @EnvironmentObject var locationManager: LocationManager
+    @EnvironmentObject var service: FriendLocationService
+
+    var body: some View {
+        ZStack {
+            Map(coordinateRegion: $locationManager.region, showsUserLocation: true, annotationItems: service.friends) { friend in
+                MapMarker(coordinate: friend.coordinate, tint: .blue)
+            }
+            .ignoresSafeArea()
+
+            VStack {
+                HStack {
+                    Text("Your location: \(locationManager.lastLocation?.coordinate.latitude ?? 0), \(locationManager.lastLocation?.coordinate.longitude ?? 0)")
+                        .padding()
+                    Spacer()
+                }
+                Spacer()
+            }
+        }
+        .onAppear {
+            locationManager.requestPermission()
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(LocationManager())
+            .environmentObject(FriendLocationService())
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,38 @@
-# hello-world
-Try
-print("falan")
-abra aha
+# FriendFinder
+
+An iOS application that helps you locate your friends at a festival in real time. The app displays your position and your friends' positions on a map and updates them periodically.
+
+## Features
+
+- Uses CoreLocation to obtain precise user location.
+- Shows user and friends on an interactive MapKit map.
+- Periodically sends your location to a backend and fetches your friends' locations.
+- Designed for iOS 15+ (compatible with iPhone 7 and iPhone 14).
+
+## Project Structure
+
+```
+FriendFinder/
+  App/
+    FriendFinderApp.swift       # SwiftUI entry point
+  Model/
+    LocationManager.swift       # Handles location permissions and updates
+  Networking/
+    FriendLocationService.swift # Stub network layer for sharing location
+  View/
+    ContentView.swift           # Main interface with map
+```
+
+## Building the App
+
+1. Open `FriendFinder.xcodeproj` or create a new Xcode project and add the files under `FriendFinder/`.
+2. Ensure your deployment target is set to **iOS 15.0** or higher.
+3. Add the following keys to your `Info.plist` to request location permissions:
+   - `NSLocationWhenInUseUsageDescription`
+   - `NSLocationAlwaysAndWhenInUseUsageDescription`
+4. Replace the TODOs in `FriendLocationService.swift` with calls to your backend API for sharing and retrieving locations.
+5. Build and run on your devices.
+
+## Notes
+
+This repository does not include server-side code. You will need a backend service to store each user's current location and provide it to other users. Firebase Realtime Database or a simple REST API are common approaches.


### PR DESCRIPTION
## Summary
- add SwiftUI skeleton for real-time friend location app
- provide location manager, map view, and networking stubs
- update README with build instructions

## Testing
- `swiftc FriendFinder/App/FriendFinderApp.swift -o /tmp/app` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6867b9fc96188332b8a9f26abd3b5655